### PR TITLE
Export tick counter in CPU state

### DIFF
--- a/cpu.c
+++ b/cpu.c
@@ -142,6 +142,7 @@ static state_t cpu_state = {
 	.sp = &sp,
 	.flags = &flags,
 
+	.tick_counter = &tick_counter,
 	.clk_timer_timestamp = &clk_timer_timestamp,
 	.prog_timer_timestamp = &prog_timer_timestamp,
 	.prog_timer_enabled = &prog_timer_enabled,

--- a/cpu.h
+++ b/cpu.h
@@ -75,6 +75,7 @@ typedef struct {
 	u8_t *sp;
 	u4_t *flags;
 
+	u32_t *tick_counter;
 	u32_t *clk_timer_timestamp;
 	u32_t *prog_timer_timestamp;
 	bool_t *prog_timer_enabled;


### PR DESCRIPTION
Otherwise we do a flurry of tick increments after a state is loaded to catch up to the stored timer tick values, because `clk_timer_timestamp` and `prog_timer_timestamp` are stored relative to `tick_counter` but the `tick_counter` is not saved.