### PR TITLE
Export function to refresh hw state (via hal) from memory

### DIFF
--- a/cpu.c
+++ b/cpu.c
@@ -573,6 +573,24 @@ static void set_memory(u12_t n, u4_t v)
 	g_hal->log(LOG_MEMORY, "Write 0x%X - Address 0x%03X - PC = 0x%04X\n", v, n, pc);
 }
 
+void cpu_refresh_hw_from_memory() {
+	const struct range {
+		u12_t from;
+		u12_t to;
+	} refresh_locs[] = {
+		{ 0xE00, 0xE4F }, /* Display Memory 1 */
+		{ 0xE80, 0xECF }, /* Display Memory 2 */
+		{ 0xF74, 0xF74 }, /* Buzzer frequency */
+		{ 0xF54, 0xF54 }, /* Buzzer enabled */
+		{ 0, 0 }, // end of list
+	};
+	for (int i=0; refresh_locs[i].to != 0; i++) {
+		for (u12_t n = refresh_locs[i].from; n <= refresh_locs[i].to; n++) {
+			set_memory(n, memory[n]);
+		}
+	}
+}
+
 static u4_t get_rq(u12_t rq)
 {
 	switch (rq & 0x3) {

--- a/cpu.h
+++ b/cpu.h
@@ -108,4 +108,6 @@ void cpu_release(void);
 
 int cpu_step(void);
 
+void cpu_refresh_hw_from_memory(void);
+
 #endif /* _CPU_H_ */

--- a/tamalib.h
+++ b/tamalib.h
@@ -29,6 +29,7 @@
 #define tamalib_set_speed(speed)			cpu_set_speed(speed)
 
 #define tamalib_get_state()				cpu_get_state()
+#define tamalib_refresh_hw_from_state()			cpu_refresh_hw_from_memory()
 
 #define tamalib_add_bp(list, addr)			cpu_add_bp(list, addr)
 #define tamalib_free_bp(list)				cpu_free_bp(list)


### PR DESCRIPTION
This can be used after a state restore to reconstruct the appropriate LCD contents, buzzer frequency, etc.