### PR TITLE
Make LOW_FOOTPRINT optional

### DIFF
--- a/cpu.h
+++ b/cpu.h
@@ -33,12 +33,15 @@
 #define MEM_IO_ADDR				0xF00
 #define MEM_IO_SIZE				0x080
 
-/* Define this if you want to reduce the footprint of the memory buffer from 4096 u4_t (most likely bytes)
- * to 464 u8_t (bytes for sure), while increasing slightly the number of operations needed to read/write from/to it.
- */
-#define LOW_FOOTPRINT
+#ifndef LOW_FOOTPRINT
+  /* Reduce the footprint of the memory buffer from 4096 u4_t (most likely bytes)
+   * to 464 u8_t (bytes for sure), while increasing slightly the number of
+   * operations needed to read/write from/to it.
+   */
+  #define LOW_FOOTPRINT 1
+#endif
 
-#ifdef LOW_FOOTPRINT
+#if LOW_FOOTPRINT
 /* Invalid memory areas are not buffered to reduce the footprint of the library in memory */
 #define MEM_BUFFER_SIZE				(MEM_RAM_SIZE + MEM_DISPLAY1_SIZE + MEM_DISPLAY2_SIZE + MEM_IO_SIZE)/2
 


### PR DESCRIPTION
Right now, `cpu.h` implies that `LOW_FOOTPRINT` can be set or unset to change the memory access behavior of the emulator, but it defines itself right before accessing, so it is not possible to disable without modifying the library.

This PR makes `LOW_FOOTPRINT` the default behavior but also allows the user to define it to 0 if the behavior isn't desired.